### PR TITLE
vim-project was not working on mac

### DIFF
--- a/autoload/project/config.vim
+++ b/autoload/project/config.vim
@@ -2,8 +2,8 @@ let s:projects = {}
 let s:pos = 0
 
 function! s:full_path(arg) abort
-  let arg = substitute(a:arg, '\v\C/+$', '', '')
-  let arg = resolve(fnamemodify(arg, ":p"))
+  let arg = resolve(fnamemodify(a:arg, ":p"))
+  let arg = substitute(arg, '\v\C/+$', '', '')
   let arg = substitute(arg, '\v\C\\+$', '', '')
   return arg
 endfunction


### PR DESCRIPTION
Thanks for the great project.  Sadly, it wasn't working on the mac using vim 7.3-66.  The BufEnter auto command was never triggering since it looked something like /path/to/project//\* and was failing to match everything.

My fix is to change the order of operations in the full_path function to strip the trailing slash after calling resolve.  With this change, things work beautifully.
