### PR TITLE
More enhancements and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you don't want ``Welcome`` to appear when you start vim:
 let g:project_enable_welcome = 0
 " if you want the NERDTree integration.
 let g:project_use_nerdtree = 1
+" if you want to suppress the gui title changes
+let g:project_enable_title_change = 0
 
 set rtp+=~/.vim/bundle/vim-project/
 call project#rc("~/Code")

--- a/autoload/project.vim
+++ b/autoload/project.vim
@@ -14,13 +14,17 @@ command! -nargs=0 -bar Welcome
 \ enew | call project#config#welcome()
 
 if has("gui_running")
-  function! TabTitle()
-    let title = expand("%:p:t")
-    let t:title = exists("b:title") ? b:title : title
-  endfunction
+    function! TabTitle()
+      if get(g:, 'project_enable_title_change', 1)
+        let title = expand("%:p:t")
+        let t:title = exists("b:title") ? b:title : title
+      endif
+    endfunction
 
-  au VimEnter * set guitablabel=%-2.2N%{gettabvar(v:lnum,'title')}
-  set title
+  if get(g:, 'project_enable_title_change', 1)
+    au VimEnter * set guitablabel=%-2.2N%{gettabvar(v:lnum,'title')}
+    set title
+  endif
 endif
 
 if get(g:, 'project_enable_welcome', 1)

--- a/autoload/project/config.vim
+++ b/autoload/project/config.vim
@@ -2,8 +2,8 @@ let s:projects = {}
 let s:pos = 0
 
 function! s:full_path(arg) abort
-  let arg = substitute(a:arg, '\v\C/+$', '', '')
-  let arg = resolve(fnamemodify(arg, ":p"))
+  let arg = resolve(fnamemodify(a:arg, ":p"))
+  let arg = substitute(arg, '\v\C/+$', '', '')
   let arg = substitute(arg, '\v\C\\+$', '', '')
   return arg
 endfunction

--- a/autoload/project/config.vim
+++ b/autoload/project/config.vim
@@ -226,7 +226,7 @@ function! s:setup() abort
       endif
       execute autocmd
     endfor
-    if has("gui_running")
+    if has("gui_running") && get(g:, 'project_enable_title_change', 1)
       au BufEnter,BufRead,WinEnter * call TabTitle()
       au BufEnter,BufRead,WinEnter * let &titlestring = getcwd()
     endif


### PR DESCRIPTION
This includes the last pull request, but modified to strip the trailing slash twice.

Also included in this (and maybe these should be separate requests -- just let me know if I need to do this differently):
1. Fixed a bug where launching a project from the welcome screen did not properly set the local directory when nerdtree was enabled.  Moving lcd before the nerdtree open fixed that issue.
2. Added the callbacks in when launching from the welcome screen so the environment can be configured for the new doc.  Also run these before nerdtree to allow for NERDTreeIgnore configuration to be set.  Note: the callbacks are only running when nerdtree is enabled and a new file is being opened.
3. I'm not a huge fan of the title changes.  I added an option to leave the title alone.  The default behavior remains the same.
