### PR TITLE
Add new GoProject command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## News
+* New command ``GoProject`` to select a project from the ``cmdline mode``
 * [New feature](#callbacks) ``project#utils#alternate``. To alternate between `file.ext` and
   ``file_suffix.ext`` or ``fileSuffix.ext`` with the command ``:A``
 * [Windows support added](https://twitter.com/amiorin/status/336003331984076800)
@@ -6,10 +7,10 @@
 ## Introduction
 A Project is made of :
 * One directory (the ``root of the project``)
-* One title (by default the last part of the the ``root of the project``)
+* One title (by default the last part of the ``root of the project``)
 * One or more ``callbacks``
 
-Everytime you open a file nested in the ``root of the project``
+Every time you open a file nested in the ``root of the project``
 * the ``local current directory`` is changed to the ``root of the project``
 * the ``guitablabel`` is set to the ``title`` of the project
 * the ``callbacks`` of the project are executed
@@ -17,7 +18,7 @@ Everytime you open a file nested in the ``root of the project``
 ![img][0]
 
 ## Commands
-There are four commands :
+There are five commands :
 * ``Project``
 It's used inside the ``.vimrc``. The first parameter is the ``path`` to the
 project. The second parameter is optional and it is the ``title`` of the
@@ -48,9 +49,13 @@ doesn't change the ``local current directory``.
 It's used inside the ``.vimrc``. The first parameter is the ``title`` of a
 project already defined with ``Project`` or ``File``. The second parameter is
 the name a function or an array of function names. This function or these
-functions are callbacks and they are executed everytime a file nested in the
+functions are callbacks and they are executed every time a file nested in the
 ``root of the project`` is opened with **one parameter** that is the ``title``
 of the project.
+* ``GoProject``
+It's used inside the ``cmdline mode`` to switch to one of the defined projects.
+The required parameter is the ``title`` of the project without quotation. Completion
+is supported.
 * ``Welcome`` It's the [``Startify``](https://github.com/mhinz/vim-startify) equivalent.
 If you don't want ``Welcome`` to appear when you start vim:
 
@@ -88,7 +93,7 @@ Project  'nugg.ad/nuggad-compiler'
 
 " project#utils#alternate returns a dictionary with a method ``invoke(title)``.
 "
-" everytime we open a file inside the project if the path starts with
+" every time we open a file inside the project if the path starts with
 " ``spec`` or ``src`` the commands :A are defined.
 "
 " +_spec means add _spec to the file

--- a/autoload/project.vim
+++ b/autoload/project.vim
@@ -13,6 +13,9 @@ command! -complete=file -nargs=+ ProjectPath
 command! -nargs=0 -bar Welcome
 \ enew | call project#config#welcome()
 
+command! -nargs=1 -complete=custom,project#config#choices GoProject
+\ call project#config#goto(<q-args>)
+
 if has("gui_running")
   function! TabTitle()
     let title = expand("%:p:t")

--- a/autoload/project/config.vim
+++ b/autoload/project/config.vim
@@ -179,6 +179,30 @@ function! project#config#welcome() abort
   call cursor(special ? 4 : 2, 5)
 endfunction
 
+function! project#config#goto(title) abort
+  if has_key(s:projects, a:title)
+    let v = s:projects[a:title]
+    if v["type"] == "project"
+      let file = v["project"]
+      let lcd = " | lcd ".v["project"]
+    else
+      let file = v["event"]
+      let lcd = ""
+    endif
+    if get(g:, 'project_use_nerdtree', 0) && isdirectory(file)
+      execute 'enew | NERDTree '. s:escape(file).lcd
+    else
+      execute 'edit '. s:escape(file).lcd
+    endif
+  else
+    echo 'Unknown project ' . a:title
+  endif
+endfunction
+
+function! project#config#choices(ArgLead, CmdLine, CursorPos) abort
+  return join(sort(keys(s:projects)), "\n")
+endfunction
+
 function! s:escape(path) abort
   return !exists('+shellslash') || &shellslash ? fnameescape(a:path) : escape(a:path, '\')
 endfunction


### PR DESCRIPTION
Add a new command "GoProject" that can be used in "cmdline mode" to go to one of the defined projects. More efficient than doing "Welcome" and making a selection. Supports auto-complete of the project title based on the list of defined projects.
